### PR TITLE
Fixed a bug with multiple pages. Added a Content tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
                     </tfoot>
                     <tbody>
                       <tr ng-class="getSelectedRow($index)" class="revealed network-item network-type-{{entry.name}}" data-id="{{entry.id}}" ng-repeat="entry in page.entries | filter:query | filter:type | orderBy:predicate:reverse">
-                        <td class="name-column" ng-click="showDetails($index)"><div title="{{entry.url}}"><img class="icon">{{entry.parsedURL.lastPathComponent}}<div class="network-cell-subtitle">{{entry.folder}}</div></div></td>
+                        <td class="name-column" ng-click="showDetails($index, entry)"><div title="{{entry.url}}"><img class="icon">{{entry.parsedURL.lastPathComponent}}<div class="network-cell-subtitle">{{entry.folder}}</div></div></td>
                         <td class="method-column"><div title="{{entry.method}}">{{entry.method}}</div></td>
                         <td class="status-column"><div title="{{entry.status}} {{entry.statusText}}">{{entry.status}}<div class="network-cell-subtitle">{{entry.statusText}}</div></div></td>
                         <td class="type-column"><div title="{{entry.mimeType}}">{{entry.mimeType}}</div></td>
@@ -243,6 +243,7 @@
                     <div ng-click="showTab(1)" ng-class="getTab(1)" class="tabbed-pane-header-tab selected"><span class="tabbed-pane-header-tab-title" title="">Headers</span></div>
                     <div ng-click="showTab(2)" ng-class="getTab(2)" class="tabbed-pane-header-tab"><span class="tabbed-pane-header-tab-title" title="">Cookies</span></div>
                     <div ng-click="showTab(3)" ng-class="getTab(3)" class="tabbed-pane-header-tab"><span class="tabbed-pane-header-tab-title" title="">Timing</span></div>
+                    <div ng-click="showTab(4)" ng-class="getTab(4)" class="tabbed-pane-header-tab"><span class="tabbed-pane-header-tab-title" title="">Content</span></div>
                   </div>
                 </div>
               </div>
@@ -386,6 +387,9 @@
                       </td>
                     </tr>
                   </table>
+                </div>
+                <div ng-class="getVisibleTab(4)" class="resource-timing-view">
+                  <p><pre>{{selectedEntry._entry.response.content.text}}</pre></p>
                 </div>
               </div>
             </div>

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -101,9 +101,9 @@
       $('.response.children').toggleClass('expanded');
     };
 
-    $scope.showDetails = function(i) {
+    $scope.showDetails = function(i, entry) {
       $scope.selectedRow = i;
-      $scope.selectedEntry = $scope.entries[i];
+      $scope.selectedEntry = entry;
 
       var $leftView = $('.split-view-sidebar-left');
       $('#network-views').removeClass('hidden');


### PR DESCRIPTION
I wanted to add the content member for entries as another tab. Along the way I ran into a bug with it using the index of the entry within the page it was in, which doesn't work well when trying to pull entries on the second page and beyond. I changed it to instead just pass the entry directly.
