### PR TITLE
add `title` attributes for subtext in table cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,19 +147,19 @@
                     </tfoot>
                     <tbody>
                       <tr ng-class="getSelectedRow($index)" class="revealed network-item network-type-{{entry.name}}" data-id="{{entry.id}}" ng-repeat="entry in page.entries | filter:query | filter:type | orderBy:predicate:reverse">
-                        <td class="name-column" ng-click="showDetails($index)"><div title="{{entry.url}}"><img class="icon">{{entry.parsedURL.lastPathComponent}}<div class="network-cell-subtitle">{{entry.folder}}</div></div></td>
+                        <td class="name-column" ng-click="showDetails($index)" title="{{entry.url}}"><div><img class="icon">{{entry.parsedURL.lastPathComponent}}<div class="network-cell-subtitle">{{entry.folder}}</div></div></td>
                         <td class="method-column"><div title="{{entry.method}}">{{entry.method}}</div></td>
-                        <td class="status-column"><div title="{{entry.status}} {{entry.statusText}}">{{entry.status}}<div class="network-cell-subtitle">{{entry.statusText}}</div></div></td>
-                        <td class="type-column"><div title="{{entry.mimeType}}">{{entry.mimeType}}</div></td>
-                        <td class="size-column"><div title="{{entry.size}}">{{entry.size}}<div class="network-cell-subtitle">{{entry.contentSize}}</div></div></td>
-                        <td class="time-column"><div title="{{entry.time}}">{{entry.time}}<div class="network-cell-subtitle">{{entry.latency}}</div></div></td>
+                        <td class="status-column" title="{{entry.status}} {{entry.statusText}}"><div>{{entry.status}}<div class="network-cell-subtitle">{{entry.statusText}}</div></div></td>
+                        <td class="type-column" title="{{entry.mimeType}}"><div>{{entry.mimeType}}</div></td>
+                        <td class="size-column"><div title="{{entry.size}}">{{entry.size}}<div class="network-cell-subtitle" title="{{entry.contentSize}}">{{entry.contentSize}}</div></div></td>
+                        <td class="time-column"><div title="{{entry.time}}">{{entry.time}}<div class="network-cell-subtitle"  title="{{entry.latency}}">{{entry.latency}}</div></div></td>
                         <td class="timeline-column">
                           <div class="network-graph-side network-type-{{entry.name}}">
                             <div class="network-graph-bar-area">
-                              <div class="network-graph-bar waiting" style="left: {{entry.graphs.latency_left}}%; right: {{entry.graphs.latency_right}}%;" title=""></div>
-                              <div class="network-graph-bar" style="left: {{entry.graphs.receiving_left}}%;  right: {{entry.graphs.receiving_right}}%;" title=""></div>
-                              <div class="network-graph-label waiting" title="">{{entry.latency}}</div>
-                              <div class="network-graph-label after" title="">{{entry.receiveTime}}</div>
+                              <div class="network-graph-bar waiting" style="left: {{entry.graphs.latency_left}}%; right: {{entry.graphs.latency_right}}%;"></div>
+                              <div class="network-graph-bar" style="left: {{entry.graphs.receiving_left}}%;  right: {{entry.graphs.receiving_right}}%;"></div>
+                              <div class="network-graph-label waiting" title="{{entry.latency}}">{{entry.latency}}</div>
+                              <div class="network-graph-label after" title="{{entry.receiveTime}}">{{entry.receiveTime}}</div>
                             </div>
                           </div>
                         </td>


### PR DESCRIPTION
Although Chrome does not provide these additional `title` attributes for the text below the main text (except in the case of "Status"), the ability to hover over for `title` text is useful when the text is truncated.
