### PR TITLE
Extended end of timeline to account for all entries in the HAR.

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -19,7 +19,7 @@
   }
 
   function getType(ct, url) {
-    if (ct == undefined)
+    if (ct === undefined)
       return 'oth';
     ct = ct.toLowerCase();
     if (ct.substr(0, 8) === 'text/css') {

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -19,8 +19,9 @@
   }
 
   function getType(ct, url) {
-    if (ct === undefined)
+    if (ct === undefined) {
       return 'oth';
+    }
     ct = ct.toLowerCase();
     if (ct.substr(0, 8) === 'text/css') {
       return 'css';

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -92,7 +92,7 @@
       // Often times, page loading continues in the background via ajax
       // after the initial page load.
       // Check the individual entries to find determine the last item loaded
-      // and use it to scale the dea
+      // and use it to scale the timeline.
       $.each(newData.log.entries, function(i, entry) {
         var startTime = new Date(entry.startedDateTime).getTime();
         var relativeEndTime = startTime + entry.time - new Date(pages[0].startedDateTime).getTime();

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -96,7 +96,7 @@
       $.each(newData.log.entries, function(i, entry) {
         var startTime = new Date(entry.startedDateTime).getTime();
         var relativeEndTime = startTime + entry.time - new Date(pages[0].startedDateTime).getTime();
-        if(!data.lastOnLoad || data.lastOnLoad < relativeEndTime) {
+        if (!data.lastOnLoad || data.lastOnLoad < relativeEndTime) {
           data.lastOnLoad = relativeEndTime;
         }
       });


### PR DESCRIPTION
Hi there,

The commits includes fixes to two problems I encountered:
1. Some HAR log entries may have an undefined mime-type field
   
   In those cases, the program bails out at controllers.js line 22. No entries are, then, displayed, leaving only the page load time summary (gray bar) on the screen. The quick fix categorizes those entries as "others" to allow processing to continue.
2. chromeHAR didn't always scale the timeline correctly
   
   Currently, chromeHAR walkes through log.pages array in the HAR to determine where the end of the timeline should be. This doesn't work very well for pages that perform async data requests after the page loads. The fix iterates through each of the entries included in the HAR to determine the relative load time of the last entry and uses that as the end of the timeline instead.
