### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Chrome HAR Viewer#
+# Chrome HAR Viewer #
 -
 
 [![Code Climate](https://codeclimate.com/github/ericduran/chromeHAR.png)](https://codeclimate.com/github/ericduran/chromeHAR) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ericduran/chromehar/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
